### PR TITLE
Add CoinoSwap (swap services) with XCH/USDT deep link

### DIFF
--- a/_data/links.yml
+++ b/_data/links.yml
@@ -2712,3 +2712,12 @@
   tags: [swap services]
   description: " "
   date: 2025-03-12
+
+- name: CoinoSwap
+  url: https://coinoswap.com/
+  pair: XCH/USDT
+  pair_url: https://www.coinoswap.com/?to=xch&toNetwork=xch&from=usdt&fromNetwork=trx&sellAmount=125&direction=direct
+  tags: [swap services]
+  description: " "
+  date: 2025-08-11
+


### PR DESCRIPTION
## Type of Change
- [x] Add/update/delete link
- [ ] Add/update/delete news mention
- [ ] Add/update/delete roadmap item
- [ ] Update FAQ
- [ ] Update custom page (e.g., wallets, donations etc.)
- [ ] Other site update (reference issue #)

## Link and News updates

### Added
- **CoinoSwap** (category: swap services)
  - Site: https://coinoswap.com/
  - Pair: XCH/USDT
  - Deep link: https://www.coinoswap.com/?to=xch&toNetwork=xch&from=usdt&fromNetwork=trx&sellAmount=125&direction=direct
  - Notes: neutral description, no referral params; placed alphabetically with other swap services.

### Updated
- *N/A*

### Removed
- *N/A*

## Reviewers/Approvers
@SlowestTimelord @cmarslender
